### PR TITLE
Add body to arguments of buildRequest().

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -5,7 +5,6 @@ import (
 	"github.com/headzoo/surf/errors"
 	"github.com/headzoo/surf/jar"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -479,8 +478,8 @@ func (bow *Browser) buildClient() *http.Client {
 
 // buildRequest creates and returns a *http.Request type.
 // Sets any headers that need to be sent with the request.
-func (bow *Browser) buildRequest(method, url string, ref *url.URL) (*http.Request, error) {
-	req, err := http.NewRequest(method, url, nil)
+func (bow *Browser) buildRequest(method, url string, ref *url.URL, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +496,7 @@ func (bow *Browser) buildRequest(method, url string, ref *url.URL) (*http.Reques
 // When via is not nil, and AttributeSendReferer is true, the Referer header will
 // be set to ref.
 func (bow *Browser) httpGET(u *url.URL, ref *url.URL) error {
-	req, err := bow.buildRequest("GET", u.String(), ref)
+	req, err := bow.buildRequest("GET", u.String(), ref, nil)
 	if err != nil {
 		return err
 	}
@@ -508,15 +507,10 @@ func (bow *Browser) httpGET(u *url.URL, ref *url.URL) error {
 // When via is not nil, and AttributeSendReferer is true, the Referer header will
 // be set to ref.
 func (bow *Browser) httpPOST(u *url.URL, ref *url.URL, contentType string, body io.Reader) error {
-	req, err := bow.buildRequest("POST", u.String(), ref)
+	req, err := bow.buildRequest("POST", u.String(), ref, body)
 	if err != nil {
 		return err
 	}
-	rc, ok := body.(io.ReadCloser)
-	if !ok && body != nil {
-		rc = ioutil.NopCloser(body)
-	}
-	req.Body = rc
 	req.Header.Add("Content-Type", contentType)
 
 	return bow.httpRequest(req)


### PR DESCRIPTION
Some web servers require Content-Length Header for POST requests.
We should set http.Request.ContentLength field properly.

When we set Request.Body manually, we should set Request.ContentLength manually too.

http.NewRequest() sets ContentLength field automatically, so we may use it.
