### PR TITLE
Extend osName and osVersion to work on various systems

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"runtime"
 	"strings"
-	"syscall"
 	"text/template"
 )
 
@@ -357,37 +356,4 @@ func createFromDetails(bname, bver, osname, osver string, c []string) string {
 	t.Execute(buff, data)
 
 	return buff.String()
-}
-
-// osName returns the name of the OS.
-func osName() string {
-	buf := &syscall.Utsname{}
-	err := syscall.Uname(buf)
-	if err != nil {
-		return "Linux"
-	}
-	return charsToString(buf.Sysname)
-}
-
-// osVersion returns the OS version.
-func osVersion() string {
-	buf := &syscall.Utsname{}
-	err := syscall.Uname(buf)
-	if err != nil {
-		return "0.0"
-	}
-	return charsToString(buf.Release)
-}
-
-// charsToString converts a [65]int8 byte array into a string.
-func charsToString(ca [65]int8) string {
-	s := make([]byte, len(ca))
-	var lens int
-	for ; lens < len(ca); lens++ {
-		if ca[lens] == 0 {
-			break
-		}
-		s[lens] = uint8(ca[lens])
-	}
-	return string(s[0:lens])
 }

--- a/agent/agent_bsd.go
+++ b/agent/agent_bsd.go
@@ -1,0 +1,26 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package agent
+
+import (
+	"runtime"
+	"syscall"
+)
+
+// osName returns the name of the OS.
+func osName() string {
+	name, err := syscall.Sysctl("kern.ostype")
+	if err != nil {
+		return runtime.GOOS
+	}
+	return name
+}
+
+// osVersion returns the OS version.
+func osVersion() string {
+	release, err := syscall.Sysctl("kern.osrelease")
+	if err != nil {
+		return "0.0"
+	}
+	return release
+}

--- a/agent/agent_linux.go
+++ b/agent/agent_linux.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package agent
+
+import (
+	"runtime"
+	"syscall"
+)
+
+// osName returns the name of the OS.
+func osName() string {
+	buf := &syscall.Utsname{}
+	err := syscall.Uname(buf)
+	if err != nil {
+		return runtime.GOOS
+	}
+	return charsToString(buf.Sysname)
+}
+
+// osVersion returns the OS version.
+func osVersion() string {
+	buf := &syscall.Utsname{}
+	err := syscall.Uname(buf)
+	if err != nil {
+		return "0.0"
+	}
+	return charsToString(buf.Release)
+}
+
+// charsToString converts a [65]int8 byte array into a string.
+func charsToString(ca [65]int8) string {
+	s := make([]byte, len(ca))
+	var lens int
+	for ; lens < len(ca); lens++ {
+		if ca[lens] == 0 {
+			break
+		}
+		s[lens] = uint8(ca[lens])
+	}
+	return string(s[0:lens])
+}

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -1,0 +1,25 @@
+// +build windows
+
+package agent
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+)
+
+// osName returns the name of the OS.
+func osName() string {
+	return runtime.GOOS
+}
+
+// osVersion returns the OS version.
+func osVersion() string {
+	v, err := syscall.GetVersion()
+	if err != nil {
+		return "0.0"
+	}
+	major := uint8(v)
+	minor := uint8(v >> 8)
+	return fmt.Sprintf("%d.%d", major, minor)
+}


### PR DESCRIPTION
Another implementation to fix #4. This separates `osName` and `osVersion` into each system's own files and doesn't have `uname` command dependency.