### PR TITLE
browser.Post() sends current URL as referrer

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -199,7 +199,7 @@ func (bow *Browser) OpenBookmark(name string) error {
 	return bow.Open(url)
 }
 
-// Post requests the given URL using the POST method. The current page will be listed as the referer.
+// Post requests the given URL using the POST method.
 func (bow *Browser) Post(u string, contentType string, body io.Reader) error {
 	ur, err := url.Parse(u)
 	if err != nil {

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -199,13 +199,13 @@ func (bow *Browser) OpenBookmark(name string) error {
 	return bow.Open(url)
 }
 
-// Post requests the given URL using the POST method.
+// Post requests the given URL using the POST method. The current page will be listed as the referer.
 func (bow *Browser) Post(u string, contentType string, body io.Reader) error {
 	ur, err := url.Parse(u)
 	if err != nil {
 		return err
 	}
-	return bow.httpPOST(ur, nil, contentType, body)
+	return bow.httpPOST(ur, bow.Url(), contentType, body)
 }
 
 // PostForm requests the given URL using the POST method with the given data.


### PR DESCRIPTION
Basically, I'm trying to send a request (by using `browser.PostForm()`) where, in order for it to succeed:

- A CSRF-related cookie must be obtained from the server by loading a page
- The CSRF token must be added in the request header
- The "Referer" header must be set to the proper value (the page which served the CSRF token)

The most intuitive way to do this is just to make a browser with the `SendReferer` attribute set, then `browser.Open()` to the page that sets the cookie. Then I use `browser.PostForm()` to submit the request. The problem was that the Referer header wasn't being set because of that nil argument. This change makes it work all fine and dandy.

(I know I could just have done AddRequestHeader to set the referrer manually, but since the browser state is already on that page and SendReferer is true, this change just seems more intuitive. But I'm open to discussing it.)