### PR TITLE
Fix assumption that all input fields in a form have a value attribute.

### DIFF
--- a/browser/form.go
+++ b/browser/form.go
@@ -151,9 +151,10 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values) {
 					}
 				} else {
 					val, ok := s.Attr("value")
-					if ok {
-						fields.Add(name, val)
+					if !ok {
+						val = ""
 					}
+					fields.Add(name, val)
 				}
 			}
 		}


### PR DESCRIPTION
Fix assumption that all input fields in a form have a value attribute. If no value is found in the form we default to "".

Not doing this causes all form input fields that have no value attribute to be elided from the list of form fields we can set.