### PR TITLE
Fixing http request handling

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -437,7 +437,7 @@ func (bow *Browser) SetHeadersJar(h http.Header) {
 
 // AddRequestHeader sets a header the browser sends with each request.
 func (bow *Browser) AddRequestHeader(name, value string) {
-	bow.headers.Add(name, value)
+	bow.headers.Set(name, value)
 }
 
 // DelRequestHeader deletes a header so the browser will not send it with future requests.
@@ -523,9 +523,9 @@ func (bow *Browser) buildRequest(method, url string, ref *url.URL, body io.Reade
 		return nil, err
 	}
 	req.Header = bow.headers
-	req.Header.Add("User-Agent", bow.userAgent)
+	req.Header.Set("User-Agent", bow.userAgent)
 	if bow.attributes[SendReferer] && ref != nil {
-		req.Header.Add("Referer", ref.String())
+		req.Header.Set("Referer", ref.String())
 	}
 
 	return req, nil


### PR DESCRIPTION
Before this fix all Header handling was **adding** to the header values, not setting them:

Here is a sample of the traced headers, for calling browser a couple of times
```
[HACK] before login
===== [DUMP] =====
 GET /account/login/ HTTP/1.1
Host: hub.docker.com
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
 
 
[HACK] submit login ...
===== [DUMP] =====
 POST /account/login/ HTTP/1.1
Host: hub.docker.com
Referer: https://hub.docker.com/account/login/
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
 
 
[HACK] login success
  - csrftoken [] T5CW6NekaS40J9AiARgS8ma7m9lZFBiQ
  - docker_sso_username [] sequenceiq
  - sessionid [] bpvtto7wf0vpg3fdwyzsvxk4tujqj533
===== [DUMP] =====
 GET /u/sequenceiq/alpine-dig/ HTTP/1.1
Host: registry.hub.docker.com
Content-Type: application/x-www-form-urlencoded
Cookie: csrftoken=STwCpsKaEwT9mqfZ5ZTJSmDPf3ZixK5M
Referer: https://hub.docker.com/account/login/
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
User-Agent: Surf/1.0 (Darwin 14.3.0; go1.4.2)
```