### PR TITLE
Added Form.ClickByValue method

### DIFF
--- a/browser/form.go
+++ b/browser/form.go
@@ -13,6 +13,7 @@ type Submittable interface {
 	Action() string
 	Input(name, value string) error
 	Click(button string) error
+	ClickByValue(name, value string) error
 	Submit() error
 	Dom() *goquery.Selection
 }
@@ -82,6 +83,26 @@ func (f *Form) Click(button string) error {
 			"Form does not contain a button with the name '%s'.", button)
 	}
 	return f.send(button, f.buttons[button][0])
+}
+
+// Click submits the form by clicking the button with the given name and value.
+func (f *Form) ClickByValue(name, value string) error {
+	if _, ok := f.buttons[name]; !ok {
+		return errors.NewInvalidFormValue(
+			"Form does not contain a button with the name '%s'.", name)
+	}
+	valueNotFound := true
+	for _, val := range f.buttons[name] {
+		if val == value {
+			valueNotFound = false
+			break
+		}
+	}
+	if valueNotFound {
+		return errors.NewInvalidFormValue(
+			"Form does not contain a button with the name '%s' and value '%s'.", name, value)
+	}
+	return f.send(name, value)
 }
 
 // Dom returns the inner *goquery.Selection.

--- a/browser/form_test.go
+++ b/browser/form_test.go
@@ -10,15 +10,7 @@ import (
 )
 
 func TestBrowserForm(t *testing.T) {
-	ut.Run(t)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
-			fmt.Fprint(w, htmlForm)
-		} else {
-			r.ParseForm()
-			fmt.Fprint(w, r.Form.Encode())
-		}
-	}))
+	ts := setupTestServer(htmlForm, t)
 	defer ts.Close()
 
 	bow := &Browser{}
@@ -40,6 +32,41 @@ func TestBrowserForm(t *testing.T) {
 	ut.AssertContains("submit2=submitted2", bow.Body())
 }
 
+func TestBrowserFormClickByValue(t *testing.T) {
+	ts := setupTestServer(htmlFormClick, t)
+	defer ts.Close()
+
+	bow := &Browser{}
+	bow.headers = make(http.Header, 10)
+	bow.history = jar.NewMemoryHistory()
+
+	err := bow.Open(ts.URL)
+	ut.AssertNil(err)
+
+	f, err := bow.Form("[name='default']")
+	ut.AssertNil(err)
+
+	f.Input("age", "55")
+	err = f.ClickByValue("submit", "submitted2")
+	ut.AssertNil(err)
+	ut.AssertContains("age=55", bow.Body())
+	ut.AssertContains("submit=submitted2", bow.Body())
+}
+
+func setupTestServer(html string, t *testing.T) *httptest.Server {
+	ut.Run(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			fmt.Fprint(w, html)
+		} else {
+			r.ParseForm()
+			fmt.Fprint(w, r.Form.Encode())
+		}
+	}))
+
+	return ts
+}
+
 var htmlForm = `<!doctype html>
 <html>
 	<head>
@@ -52,6 +79,21 @@ var htmlForm = `<!doctype html>
 			<input type="radio" name="gender" value="female" />
 			<input type="submit" name="submit1" value="submitted1" />
 			<input type="submit" name="submit2" value="submitted2" />
+		</form>
+	</body>
+</html>
+`
+
+var htmlFormClick = `<!doctype html>
+<html>
+	<head>
+		<title>Echo Form</title>
+	</head>
+	<body>
+		<form method="post" action="/" name="default">
+			<input type="text" name="age" value="" />
+			<input type="submit" name="submit" value="submitted1" />
+			<input type="submit" name="submit" value="submitted2" />
 		</form>
 	</body>
 </html>


### PR DESCRIPTION
When a form has more than one button with the same name, use the value to determine which button to click. For example:
```
<input type="submit" name="submit" value="submitted1" />
<input type="submit" name="submit" value="submitted2" />
```
Normally the first button found would be clicked. Now with ClickByValue you can specify the button to click by it's name and value attribute values.