### PR TITLE
Implement http.Client reuse so we are not creating a new client with each call

### DIFF
--- a/surf_test.go
+++ b/surf_test.go
@@ -61,8 +61,8 @@ func TestPost(t *testing.T) {
 
 func TestHead(t *testing.T) {
 	ut.Run(t)
-	var r *http.Request;
-	
+	var r *http.Request
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		r = req
 	}))


### PR DESCRIPTION
Implement http.Client reuse so we are not creating a new client for every request.
Misc comment cleanup.

This change should not cause any BC breaks that I can see.  I used a Singleton to create the client and to replace the buildClient method.  Appropriate setters were changed to operate on the client as well, so all usage cases should be the same.