### PR TITLE
Add support for browser.SetTimeout

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -75,6 +75,9 @@ type Browsable interface {
 	// SetHeadersJar sets the headers the browser sends with each request.
 	SetHeadersJar(h http.Header)
 
+	// SetTimeout sets the timeout for requests.
+	SetTimeout(t time.Duration)
+
 	// SetTransport sets the http library transport mechanism for each request.
 	SetTransport(rt http.RoundTripper)
 
@@ -198,6 +201,9 @@ type Browser struct {
 
 	// body of the current page.
 	body []byte
+
+	// timeout of the request
+	timeout time.Duration
 }
 
 // Open requests the given URL using the GET method.
@@ -480,6 +486,12 @@ func (bow *Browser) SetHeadersJar(h http.Header) {
 }
 
 // SetTransport sets the http library transport mechanism for each request.
+// SetTimeout sets the timeout for requests.
+func (bow *Browser) SetTimeout(t time.Duration) {
+	bow.timeout = t
+}
+
+// SetTransport sets the http library transport mechanism for each request.
 func (bow *Browser) SetTransport(rt http.RoundTripper) {
 	bow.transport = rt
 }
@@ -569,6 +581,9 @@ func (bow *Browser) buildClient() *http.Client {
 	client.CheckRedirect = bow.shouldRedirect
 	if bow.transport != nil {
 		client.Transport = bow.transport
+	}
+	if bow.timeout != 0 {
+		client.Timeout = bow.timeout
 	}
 
 	return client

--- a/docs/api/packages/browser.md
+++ b/docs/api/packages/browser.md
@@ -193,6 +193,9 @@ type Browsable interface {
 	// SetHeadersJar sets the headers the browser sends with each request.
 	SetHeadersJar(h http.Header)
 
+	// SetTimeout sets the timeout for requests.
+	SetTimeout(t time.Duration)
+
 	// SetTransport sets the http library transport mechanism for each request.
 	SetTransport(rt http.RoundTripper)
 
@@ -529,6 +532,13 @@ SetHistoryJar is used to set the history jar the browser uses.
 func (bow *Browser) SetState(sj *jar.State)
 ```
 SetState sets the browser state.
+
+#### func (*Browser) SetTimeout
+
+```go
+func (bow *Browser) SetTimeout(t time.Duration)
+```
+SetTimeout sets the timeout for requests.
 
 #### func (*Browser) SetTransport
 


### PR DESCRIPTION
Hi,

Surf is a very nice library. For my use case it's missing a way to add a Timeout when opening a connection. The underlying http.client does support a Timeout (https://golang.org/pkg/net/http/#Client), so I went ahead and added to the browser. It works as expected in my code:
```go
browser := surf.NewBrowser()
browser.SetTimeout(10 * time.Second)
```

If you consider merging this PR, let me know if something needs to be changed.

Regards,

C.