### PR TITLE
Tor socks proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ like web browser, and includes: cookie management, history, bookmarking, user ag
 (with a nifty user agent builder), submitting forms, DOM selection and traversal via jQuery style
 CSS selectors, scraping assets like images, stylesheets, and other features.
 
-**NOTE: DEVELOPMENT ON THIS PROJECT IS VERY SLOW!**  
-I'm accepting pull requests and fixing bugs at a snail's pace right now. Partially because Surf has taken a backseat to projects which are more important to me, and the way Go handles vendoring makes me hesitant to make changes. Development will pick up again when I have more free time.
-
-Work has started on v2.0 on the [v2 branch](https://github.com/headzoo/surf/tree/v2).
-
 * [Installation](#installation)
 * [General Usage](#quick-start)
 * [Documentation](#documentation)
@@ -58,17 +53,13 @@ Complete documentation is available on [Read the Docs](http://surf.readthedocs.i
 
 
 ### Credits
-Surf was started by [Sean Hickey](https://github.com/headzoo) (headzoo) to learn more about the Go programming language.
-The idea to create Surf was born in [this Reddit thread](http://www.reddit.com/r/golang/comments/2efw1q/mechanize_in_go/cjz4lze).
-
-[![Twitter](https://img.shields.io/badge/follow-%40WebSeanHickey-orange.svg?style=flat-square)](https://twitter.com/WebSeanHickey)
-
 Surf uses the awesome [goquery](https://github.com/PuerkitoBio/goquery) by Martin Angers, and
 was written using [Intellij](http://www.jetbrains.com/idea/) and
 the [golang plugin](http://plugins.jetbrains.com/plugin/5047).
 
 Contributions have been made to Surf by the following awesome developers:
 
+* [Sean Hickey](https://github.com/headzoo)
 * [Haruyama Seigo](https://github.com/haruyama)
 * [Tatsushi Demachi](https://github.com/tatsushid)
 * [Charl Matthee](https://github.com/charl)
@@ -85,12 +76,11 @@ Contributions have been made to Surf by the following awesome developers:
 * [Joseph Watson](https://github.com/jtwatson)
 * [lxt2](https://github.com/lxt2)
 
+The idea to create Surf was born in [this Reddit thread](http://www.reddit.com/r/golang/comments/2efw1q/mechanize_in_go/cjz4lze).
+
 
 ### Contributing
-Issues and pull requests are _always_ welcome. Code changes are made to the
-[`dev`](https://github.com/headzoo/surf/tree/dev) branch. Once a milestone has been reached the branch will
-be merged in with `master`, and a new version tag created. **Do not** make your changes against the
-`master` branch, or they will _may_ be ignored.
+Issues and pull requests are _always_ welcome.
 
 See [CONTRIBUTING.md](https://raw.githubusercontent.com/headzoo/surf/master/CONTRIBUTING.md) for more information.
 

--- a/agent/agent_appengine.go
+++ b/agent/agent_appengine.go
@@ -1,0 +1,17 @@
+// +build appengine
+
+package agent
+
+import (
+	"runtime"
+)
+
+// osName returns the name of the OS.
+func osName() string {
+	return runtime.GOOS
+}
+
+// osVersion returns the OS version.
+func osVersion() string {
+	return "0.0"
+}

--- a/agent/agent_bsd.go
+++ b/agent/agent_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd netbsd openbsd
+// +build !appengine
 
 package agent
 

--- a/agent/agent_linux_arm.go
+++ b/agent/agent_linux_arm.go
@@ -1,6 +1,4 @@
-// +build linux
-// +build !appengine
-// +build !arm
+// +build linux,arm
 
 package agent
 
@@ -29,8 +27,8 @@ func osVersion() string {
 	return charsToString(buf.Release)
 }
 
-// charsToString converts a [65]int8 byte array into a string.
-func charsToString(ca [65]int8) string {
+// charsToString converts a [65]uint8 byte array into a string.
+func charsToString(ca [65]uint8) string {
 	s := make([]byte, len(ca))
 	var lens int
 	for ; lens < len(ca); lens++ {

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !appengine
 
 package agent
 

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/proxy"
+
 	"github.com/PuerkitoBio/goquery"
 	"github.com/headzoo/surf/errors"
 	"github.com/headzoo/surf/jar"
@@ -77,6 +79,9 @@ type Browsable interface {
 
 	// SetTransport sets the http library transport mechanism for each request.
 	SetTransport(rt http.RoundTripper)
+
+	// Tor sets the proxy url for Tor
+	Tor(url *url.URL) (err error)
 
 	// AddRequestHeader adds a header the browser sends with each request.
 	AddRequestHeader(name, value string)
@@ -482,6 +487,17 @@ func (bow *Browser) SetHeadersJar(h http.Header) {
 // SetTransport sets the http library transport mechanism for each request.
 func (bow *Browser) SetTransport(rt http.RoundTripper) {
 	bow.transport = rt
+}
+
+// Tor sets the proxy url for Tor
+func (bow *Browser) Tor(url *url.URL) (err error) {
+	dialer, err := proxy.FromURL(url, proxy.Direct)
+	if err != nil {
+		return err
+	}
+	bow.SetTransport(&http.Transport{Dial: dialer.Dial})
+
+	return err
 }
 
 // AddRequestHeader sets a header the browser sends with each request.

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -80,8 +80,8 @@ type Browsable interface {
 	// SetTransport sets the http library transport mechanism for each request.
 	SetTransport(rt http.RoundTripper)
 
-	// Tor sets the proxy url for Tor
-	Tor(url *url.URL) (err error)
+	// Set a proxy URL. You can use it with Tor
+	SetProxy(url *url.URL) (err error)
 
 	// AddRequestHeader adds a header the browser sends with each request.
 	AddRequestHeader(name, value string)
@@ -489,8 +489,8 @@ func (bow *Browser) SetTransport(rt http.RoundTripper) {
 	bow.transport = rt
 }
 
-// Tor sets the proxy url for Tor
-func (bow *Browser) Tor(url *url.URL) (err error) {
+// Set a proxy url for Tor
+func (bow *Browser) SetProxy(url *url.URL) (err error) {
 	dialer, err := proxy.FromURL(url, proxy.Direct)
 	if err != nil {
 		return err

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -81,7 +81,7 @@ type Browsable interface {
 	SetTransport(rt http.RoundTripper)
 
 	// Set a proxy URL. You can use it with Tor
-	SetProxy(url *url.URL) (err error)
+	SetProxy(u string) (err error)
 
 	// AddRequestHeader adds a header the browser sends with each request.
 	AddRequestHeader(name, value string)
@@ -502,8 +502,12 @@ func (bow *Browser) SetTransport(rt http.RoundTripper) {
 }
 
 // Set a proxy url for Tor
-func (bow *Browser) SetProxy(url *url.URL) (err error) {
-	dialer, err := proxy.FromURL(url, proxy.Direct)
+func (bow *Browser) SetProxy(u string) (err error) {
+	_url, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	dialer, err := proxy.FromURL(_url, proxy.Direct)
 	if err != nil {
 		return err
 	}

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -145,11 +144,7 @@ func TestCookieHeader(t *testing.T) {
 // https://github.com/headzoo/surf/pull/56
 func TestSetProxyWillSetTransport(t *testing.T){
 	b := newDefaultTestBrowser()
-	u, err := url.Parse("socks5://127.0.0.1:9050")
-	if err != nil {
-		t.Fatal(err)
-	}
-	b.SetProxy(u)
+	b.SetProxy("socks5://127.0.0.1:9050")
 	if b.client.Transport == nil {
 		t.Errorf("no transport method")
 	}

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -150,7 +150,7 @@ func TestSetProxyWillSetTransport(t *testing.T){
 		t.Fatal(err)
 	}
 	b.SetProxy(u)
-	if b.transport == nil {
+	if b.client.Transport == nil {
 		t.Errorf("no transport method")
 	}
 }

--- a/browser/browser_test.go
+++ b/browser/browser_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -137,5 +138,19 @@ func TestCookieHeader(t *testing.T) {
 
 	if want := 3; calls != want {
 		t.Errorf("got %d calls, want %d", calls, want)
+	}
+}
+
+// Test proxy
+// https://github.com/headzoo/surf/pull/56
+func TestSetProxyWillSetTransport(t *testing.T){
+	b := newDefaultTestBrowser()
+	u, err := url.Parse("socks5://127.0.0.1:9050")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.SetProxy(u)
+	if b.transport == nil {
+		t.Errorf("no transport method")
 	}
 }


### PR DESCRIPTION
To use the proxy use the `Tor(url *url.URL) (err error)` method

````
var err error
bow := surf.NewBrowser()
//err:= bow.Open("http://check.torproject.org")
//  if err != nil {
//    panic(err)
//  }
// Without proxy: Sorry. You are not using Tor.
//fmt.Println(bow.Title())

// With proxy: Congratulations. This browser is configured to use Tor.
u, _ := url.Parse("socks5://127.0.0.1:9050")
bow.Tor(u)
err = bow.Open("http://check.torproject.org")
  if err != nil {
   panic(err)
 }
fmt.Println(bow.Title())
````