### PR TITLE
Add support for appengine

### DIFF
--- a/agent/agent_appengine.go
+++ b/agent/agent_appengine.go
@@ -1,0 +1,17 @@
+// +build appengine
+
+package agent
+
+import (
+	"runtime"
+)
+
+// osName returns the name of the OS.
+func osName() string {
+	return runtime.GOOS
+}
+
+// osVersion returns the OS version.
+func osVersion() string {
+	return "0.0"
+}

--- a/agent/agent_bsd.go
+++ b/agent/agent_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin dragonfly freebsd netbsd openbsd
+// +build !appengine
 
 package agent
 

--- a/agent/agent_linux.go
+++ b/agent/agent_linux.go
@@ -1,4 +1,5 @@
 // +build linux
+// +build !appengine
 
 package agent
 

--- a/agent/agent_windows.go
+++ b/agent/agent_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !appengine
 
 package agent
 


### PR DESCRIPTION
Hi.

I want to use this great library with appengine.

But appengine does not allow import `syscall` package, 
so always build fails like below
```
2017/06/28 11:03:03 go-app-builder: Failed parsing input: parser: bad import "syscall" in github.com/headzoo/surf/agent/agent.go from GOPATH
```

I fixed a this problem using build tag. (it might be workaround, but I think works well)
refs #49 
