### PR TITLE
Feature/history trimming

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -63,14 +63,26 @@ type Browsable interface {
 	// SetState sets the init browser state.
 	SetState(sj *jar.State)
 
+	// State returns the browser state.
+	State() *jar.State
+
 	// SetBookmarksJar sets the bookmarks jar the browser uses.
 	SetBookmarksJar(bj jar.BookmarksJar)
+
+	// BookmarksJar returns the bookmarks jar the browser uses.
+	BookmarksJar() jar.BookmarksJar
 
 	// SetCookieJar is used to set the cookie jar the browser uses.
 	SetCookieJar(cj http.CookieJar)
 
+	// CookieJar returns the cookie jar the browser uses.
+	CookieJar() http.CookieJar
+
 	// SetHistoryJar is used to set the history jar the browser uses.
 	SetHistoryJar(hj jar.History)
+
+	// HistoryJar returns the history jar the browser uses.
+	HistoryJar() jar.History
 
 	// SetHeadersJar sets the headers the browser sends with each request.
 	SetHeadersJar(h http.Header)
@@ -450,12 +462,25 @@ func (bow *Browser) SetState(sj *jar.State) {
 	bow.state = sj
 }
 
+// State returns the browser state.
+func (bow *Browser) State() *jar.State {
+	return bow.state
+}
+
 // SetCookieJar is used to set the cookie jar the browser uses.
 func (bow *Browser) SetCookieJar(cj http.CookieJar) {
 	if bow.client == nil {
 		bow.client = bow.buildClient()
 	}
 	bow.client.Jar = cj
+}
+
+// CookieJar returns the cookie jar the browser uses.
+func (bow *Browser) CookieJar() http.CookieJar {
+	if bow.client == nil {
+		bow.client = bow.buildClient()
+	}
+	return bow.client.Jar
 }
 
 // SetUserAgent sets the user agent.
@@ -478,9 +503,19 @@ func (bow *Browser) SetBookmarksJar(bj jar.BookmarksJar) {
 	bow.bookmarks = bj
 }
 
+// BookmarksJar returns the bookmarks jar the browser uses.
+func (bow *Browser) BookmarksJar() jar.BookmarksJar {
+	return bow.bookmarks
+}
+
 // SetHistoryJar is used to set the history jar the browser uses.
 func (bow *Browser) SetHistoryJar(hj jar.History) {
 	bow.history = hj
+}
+
+// HistoryJar returns the history jar the browser uses.
+func (bow *Browser) HistoryJar() jar.History {
+	return bow.history
 }
 
 // SetHeadersJar sets the headers the browser sends with each request.

--- a/jar/history.go
+++ b/jar/history.go
@@ -1,8 +1,10 @@
 package jar
 
 import (
-	"github.com/PuerkitoBio/goquery"
+	"container/list"
 	"net/http"
+
+	"github.com/PuerkitoBio/goquery"
 )
 
 // State represents a point in time.
@@ -23,6 +25,8 @@ func NewHistoryState(req *http.Request, resp *http.Response, dom *goquery.Docume
 
 // History is a type that records browser state.
 type History interface {
+	Clear()
+	SetMax(max int)
 	Len() int
 	Push(p *State) int
 	Pop() *State
@@ -37,43 +41,58 @@ type Node struct {
 
 // MemoryHistory is an in-memory implementation of the History interface.
 type MemoryHistory struct {
-	top  *Node
-	size int
+	list    *list.List
+	maxHist int
 }
 
 // NewMemoryHistory creates and returns a new *StateHistory type.
 func NewMemoryHistory() *MemoryHistory {
-	return &MemoryHistory{}
+	return &MemoryHistory{list: list.New()}
 }
 
 // Len returns the number of states in the history.
 func (his *MemoryHistory) Len() int {
-	return his.size
+	return his.list.Len()
+}
+
+// SetMax sets the max history length.  Setting values
+// to 0 will disable history trimming, keeping a infinite list.
+func (his *MemoryHistory) SetMax(max int) {
+	his.maxHist = max
+}
+
+// Clear removes all history.
+func (his *MemoryHistory) Clear() {
+	his.list.Init()
 }
 
 // Push adds a new State at the front of the history.
 func (his *MemoryHistory) Push(p *State) int {
-	his.top = &Node{p, his.top}
-	his.size++
-	return his.size
+	his.list.PushFront(p)
+
+	// Trim history if maxHist is set
+	if his.maxHist > 0 {
+		if l := his.list.Len(); l > his.maxHist {
+			for i := 0; i < l-his.maxHist; i++ {
+				his.list.Remove(his.list.Back())
+			}
+		}
+	}
+	return his.list.Len()
 }
 
 // Pop removes and returns the State at the front of the history.
 func (his *MemoryHistory) Pop() *State {
-	if his.size > 0 {
-		value := his.top.Value
-		his.top = his.top.Next
-		his.size--
-		return value
+	if his.list.Len() > 0 {
+		return his.list.Remove(his.list.Front()).(*State)
 	}
-
 	return nil
 }
 
 // Top returns the State at the front of the history without removing it.
 func (his *MemoryHistory) Top() *State {
-	if his.size == 0 {
+	if his.list.Len() == 0 {
 		return nil
 	}
-	return his.top.Value
+	return his.list.Front().Value.(*State)
 }

--- a/jar/history_test.go
+++ b/jar/history_test.go
@@ -1,8 +1,9 @@
 package jar
 
 import (
-	"github.com/headzoo/ut"
 	"testing"
+
+	"github.com/headzoo/ut"
 )
 
 func TestMemoryHistory(t *testing.T) {
@@ -26,5 +27,53 @@ func TestMemoryHistory(t *testing.T) {
 
 	page = stack.Pop()
 	ut.AssertEquals(page, page1)
+	ut.AssertEquals(0, stack.Len())
+}
+
+func TestMemoryHistoryWithMax(t *testing.T) {
+	ut.Run(t)
+	stack := NewMemoryHistory()
+	stack.SetMax(2)
+
+	ut.AssertEquals(2, stack.maxHist)
+
+	page1 := &State{}
+	stack.Push(page1)
+	ut.AssertEquals(1, stack.Len())
+	ut.AssertEquals(page1, stack.Top())
+
+	page2 := &State{}
+	stack.Push(page2)
+	ut.AssertEquals(2, stack.Len())
+	ut.AssertEquals(page2, stack.Top())
+
+	page3 := &State{}
+	stack.Push(page3)
+	ut.AssertEquals(2, stack.Len())
+	ut.AssertEquals(page3, stack.Top())
+
+	page4 := &State{}
+	stack.Push(page4)
+	ut.AssertEquals(2, stack.Len())
+	ut.AssertEquals(page4, stack.Top())
+
+	page := stack.Pop()
+	ut.AssertEquals(page, page4)
+	ut.AssertEquals(1, stack.Len())
+	ut.AssertEquals(page3, stack.Top())
+
+	page = stack.Pop()
+	ut.AssertEquals(page, page3)
+	ut.AssertEquals(0, stack.Len())
+}
+
+func TestMemoryHistoryClear(t *testing.T) {
+	ut.Run(t)
+	stack := NewMemoryHistory()
+
+	stack.Push(&State{})
+	stack.Push(&State{})
+	ut.AssertEquals(2, stack.Len())
+	stack.Clear()
 	ut.AssertEquals(0, stack.Len())
 }

--- a/surf.go
+++ b/surf.go
@@ -19,6 +19,9 @@ var (
 
 	// DefaultFollowRedirects is the global value for the AttributeFollowRedirects attribute.
 	DefaultFollowRedirects = true
+
+	// DefaultMaxHistoryLength is the global value for max history length.
+	DefaultMaxHistoryLength = 0
 )
 
 // NewBrowser creates and returns a *browser.Browser type.
@@ -28,7 +31,9 @@ func NewBrowser() *browser.Browser {
 	bow.SetState(&jar.State{})
 	bow.SetCookieJar(jar.NewMemoryCookies())
 	bow.SetBookmarksJar(jar.NewMemoryBookmarks())
-	bow.SetHistoryJar(jar.NewMemoryHistory())
+	hist := jar.NewMemoryHistory()
+	hist.SetMax(DefaultMaxHistoryLength)
+	bow.SetHistoryJar(hist)
 	bow.SetHeadersJar(jar.NewMemoryHeaders())
 	bow.SetAttributes(browser.AttributeMap{
 		browser.SendReferer:         DefaultSendReferer,


### PR DESCRIPTION
Add ability to cleanup held resources by ether calling Close() on the Browser when it is no longer needed, or optionally having the ability to clear the browser history with ClearHistory()

Implemented ability to set a maximum history length that will be enforced as the history grows.