### PR TITLE
Change the default history size from unlimited to 100 pages

### DIFF
--- a/surf.go
+++ b/surf.go
@@ -21,7 +21,7 @@ var (
 	DefaultFollowRedirects = true
 
 	// DefaultMaxHistoryLength is the global value for max history length.
-	DefaultMaxHistoryLength = 0
+	DefaultMaxHistoryLength = 100
 )
 
 // NewBrowser creates and returns a *browser.Browser type.


### PR DESCRIPTION
This should provide a reasonable balance between resource consumption and preventing a BC break.

Closes #68 