### PR TITLE
error value passed to panic doesn't belong to fm.Submit()

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ func main() {
     fm, _ := bow.Form("form.login-form")
     fm.Input("user", "JoeRedditor")
     fm.Input("passwd", "d234rlkasd")
-    if fm.Submit() != nil {
+    if err := fm.Submit(); err != nil {
     	panic(err)
     }
     


### PR DESCRIPTION
if fm.Submit() != nil{
    panic(err)
    // err doesn't belong to fm.Submit()
}
