### PR TITLE
Update browser.go

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -222,6 +222,7 @@ type Browser struct {
 func (bow *Browser) buildClient() *http.Client {
 	return &http.Client{
 		CheckRedirect: bow.shouldRedirect,
+		Timeout:       bow.timeout,
 	}
 }
 

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -222,7 +222,7 @@ type Browser struct {
 func (bow *Browser) buildClient() *http.Client {
 	return &http.Client{
 		CheckRedirect: bow.shouldRedirect,
-		Timeout:       bow.timeout,
+		Timeout:       bow.timeout,
 	}
 }
 


### PR DESCRIPTION
Use the actual timeout for http client.

There should also be a default timeout of 30 minutes for example so that every request finishes at some point eventually (see https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779)