### PR TITLE
Forms: improved support

### DIFF
--- a/browser/form.go
+++ b/browser/form.go
@@ -365,7 +365,7 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 	checkboxs := make(url.Values)
 	selects := make(selects)
 	files := make(FileSet)
-	sel.Find("input,button,textarea").Each(func(_ int, s *goquery.Selection) {
+	sel.Find("input,button").Each(func(_ int, s *goquery.Selection) {
 		if v, ok := s.Attr("disabled"); ok && strings.ToLower(v) == "disabled" {
 			return
 		}
@@ -390,6 +390,12 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 		}
 	})
 
+	sel.Find("textarea").Each(func(_ int, s *goquery.Selection) {
+		name, _ := s.Attr("name")
+		val := s.Text()
+		fields.Add(name, val)
+	})
+
 	sel.Find("select").Each(func(_ int, s *goquery.Selection) {
 		if v, ok := s.Attr("disabled"); ok && strings.ToLower(v) == "disabled" {
 			return
@@ -407,7 +413,7 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 				l, _ := ss.Html()
 				selects[name].values.Add(val, strings.TrimSpace(html.UnescapeString(l)))
 				selects[name].labels.Add(strings.TrimSpace(html.UnescapeString(l)), val)
-				if sel, _ := ss.Attr("selected"); strings.ToLower(sel) != "selected" || foundSelected {
+				if _, exists := ss.Attr("selected"); !exists || foundSelected {
 					return
 				}
 				fields.Add(name, val)

--- a/browser/form.go
+++ b/browser/form.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"io"
-
 	"github.com/PuerkitoBio/goquery"
 	"github.com/headzoo/surf/errors"
 )
@@ -369,24 +368,24 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 		if v, ok := s.Attr("disabled"); ok && strings.ToLower(v) == "disabled" {
 			return
 		}
-		if name, ok := s.Attr("name"); ok {
-			val, _ := s.Attr("value")
-			t, _ := s.Attr("type")
-			t = strings.ToLower(t)
-			if t == "submit" {
-				buttons.Add(name, val)
-			} else if t == "checkbox" || t == "radio" {
-				if c, found := s.Attr("checked"); found && strings.ToLower(c) == "checked" {
-					fields.Add(name, val)
-				}
-				if t == "checkbox" {
-					checkboxs.Add(name, val)
-				}
-			} else if t == "file" {
-				files[name] = &File{}
-			} else {
+
+		name, _ := s.Attr("name")
+		val, _ := s.Attr("value")
+		t, _ := s.Attr("type")
+		t = strings.ToLower(t)
+		if t == "submit" {
+			buttons.Add(name, val)
+		} else if t == "checkbox" || t == "radio" {
+			if _, found := s.Attr("checked"); found {
 				fields.Add(name, val)
 			}
+			if t == "checkbox" {
+				checkboxs.Add(name, val)
+			}
+		} else if t == "file" {
+			files[name] = &File{}
+		} else {
+			fields.Add(name, val)
 		}
 	})
 
@@ -425,6 +424,7 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 		}
 	})
 
+	//fmt.Printf("%#v", fields)
 	return fields, buttons, checkboxs, selects, files
 }
 


### PR DESCRIPTION
When submitting a form with pre-filled values, sometimes these values are not sent.

These cases are :
- textarea
- select with a empty selected attribute (not 'selected="selected"')
- checkbox
- inputs of type submit without a name attribute.

This PR fixes theses bugs.