### PR TITLE
Pass the timeout to the http client

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -213,9 +213,6 @@ type Browser struct {
 
 	// body of the current page.
 	body []byte
-
-	// timeout of the request
-	timeout time.Duration
 }
 
 // buildClient instanciates the *http.Client used by the browser
@@ -536,7 +533,10 @@ func (bow *Browser) SetHeadersJar(h http.Header) {
 // SetTransport sets the http library transport mechanism for each request.
 // SetTimeout sets the timeout for requests.
 func (bow *Browser) SetTimeout(t time.Duration) {
-	bow.timeout = t
+	if bow.client == nil {
+		bow.client = bow.buildClient()
+	}
+	bow.client.Timeout = t
 }
 
 // SetTransport sets the http library transport mechanism for each request.


### PR DESCRIPTION
Somewhere in the past the timeout set by SetTimeout stopped being propagated to the http.Client.

This fixes it, similar to #106, but completely removes the now unneeded bow.timeout. 