### PR TITLE
[FIX] Handle selected options

### DIFF
--- a/browser/form.go
+++ b/browser/form.go
@@ -407,7 +407,14 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 				l, _ := ss.Html()
 				selects[name].values.Add(val, strings.TrimSpace(html.UnescapeString(l)))
 				selects[name].labels.Add(strings.TrimSpace(html.UnescapeString(l)), val)
-				if sel, _ := ss.Attr("selected"); strings.ToLower(sel) != "selected" || foundSelected {
+				if foundSelected {
+					return
+				}
+				sel, ok := ss.Attr("selected")
+				if !ok {
+					return
+				}
+				if sel != "" && strings.ToLower(sel) != "selected" {
 					return
 				}
 				fields.Add(name, val)

--- a/browser/form_test.go
+++ b/browser/form_test.go
@@ -177,6 +177,43 @@ func TestBrowserFormDefaultNotSelected(t *testing.T) {
 	ut.AssertEquals(surferrors.NewElementNotFound("The select element with name 'count' is not a select miltiple."), err)
 }
 
+func TestBrowserFormSelected(t *testing.T) {
+	ts := setupTestServer(`
+<!doctype html>
+<html>
+
+<head>
+	<title>Echo Form</title>
+</head>
+
+<body>
+	<form method="post" name="default">
+		<select name="count">
+            <option value="1">One</option>
+            <option value="2" Selected>Two</option>
+        </select>
+		<input type="submit" name="submit" value="submitted" />
+	</form>
+</body>
+
+</html>`, t)
+	defer ts.Close()
+
+	bow := newBrowser()
+	err := bow.Open(ts.URL)
+	ut.AssertNil(err)
+
+	f, err := bow.Form("[name='default']")
+	ut.AssertNil(err)
+
+	ut.AssertEquals(false, f.(*Form).selects["count"].multiple)
+
+	// Initial state should have defaults selected
+	err = f.Submit()
+	ut.AssertNil(err)
+	ut.AssertEquals("count=2&submit=submitted", string(bow.body))
+}
+
 func TestBrowserFormDefaultsSelected(t *testing.T) {
 	ts := setupTestServer(`
 <!doctype html>


### PR DESCRIPTION
surf can handle `selected="selected"` options, but not for `selected`.

```
<option value=3 selected>
```
