### PR TITLE
browser: fix return nil forms

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -378,7 +378,7 @@ func (bow *Browser) Forms() []Submittable {
 		return nil
 	}
 
-	forms := make([]Submittable, len)
+	var forms []Submittable
 	sel.Each(func(_ int, s *goquery.Selection) {
 		forms = append(forms, NewForm(bow, s))
 	})


### PR DESCRIPTION
Appending to an allocated slice would start appending past the last index, leading to the first len items being nil.