### PR TITLE
Treat <input type="button"> as a clickable button

### DIFF
--- a/browser/form.go
+++ b/browser/form.go
@@ -378,7 +378,7 @@ func serializeForm(sel *goquery.Selection) (url.Values, url.Values, url.Values, 
 			val, _ := s.Attr("value")
 			t, _ := s.Attr("type")
 			t = strings.ToLower(t)
-			if t == "submit" {
+			if t == "submit" || t == "button" {
 				buttons.Add(name, val)
 			} else if t == "checkbox" || t == "radio" {
 				if c, found := s.Attr("checked"); found && strings.ToLower(c) == "checked" {

--- a/browser/form_test.go
+++ b/browser/form_test.go
@@ -408,6 +408,37 @@ func TestSubmitMultipart(t *testing.T) {
 	ut.AssertContains("image=profile.png", bow.Body())
 	ut.AssertContains(fmt.Sprintf("profile.png=%s", url.QueryEscape(image)), bow.Body())
 }
+func TestBrowserFormInputButton(t *testing.T) {
+	ts := setupTestServer(`
+<!doctype html>
+<html>
+	<head>
+		<title>Echo Form</title>
+	</head>
+	<body>
+		<form method="post" action="/" name="default">
+			<input type="text" name="age" value="" />
+			<input type="button" name="btn" value="buttonvalue" />
+		</form>
+	</body>
+</html>`, t)
+	defer ts.Close()
+
+	bow := newBrowser()
+
+	err := bow.Open(ts.URL)
+	ut.AssertNil(err)
+
+	f, err := bow.Form("[name='default']")
+	ut.AssertNil(err)
+
+	err = f.Input("age", "30")
+	ut.AssertNil(err)
+	err = f.Click("btn")
+	ut.AssertNil(err)
+	ut.AssertContains("age=30", bow.Body())
+	ut.AssertContains("btn=buttonvalue", bow.Body())
+}
 
 func setupTestServer(html string, t *testing.T) *httptest.Server {
 	ut.Run(t)


### PR DESCRIPTION
Also fixes a class of issues where all buttons were being sent back as fields, causing undefined behavior on certain sites.