### PR TITLE
Make the agent support ppc64le

### DIFF
--- a/agent/agent_linux.go
+++ b/agent/agent_linux.go
@@ -1,6 +1,7 @@
 // +build linux
 // +build !appengine
 // +build !arm
+// +build !ppc64le
 
 package agent
 

--- a/agent/agent_linux_arm_ppc64le.go
+++ b/agent/agent_linux_arm_ppc64le.go
@@ -1,4 +1,4 @@
-// +build linux,arm
+// +build linux,arm linux,ppc64le
 
 package agent
 


### PR DESCRIPTION
When building for ppc64le, I saw error messages like these:
```
/root/go/pkg/mod/github.com/headzoo/surf@v1.0.1/agent/agent_linux.go:19:23: cannot use buf.Sysname (variable of type [65]uint8) as [65]int8 value in argument to charsToString
/root/go/pkg/mod/github.com/headzoo/surf@v1.0.1/agent/agent_linux.go:29:23: cannot use buf.Release (variable of type [65]uint8) as [65]int8 value in argument to charsToString
```
This PR adjusts/adds the go build tags so that the agent additionally covers ppc64le.
Legacy format of go build tags are used here just to be consistent with existing ones.